### PR TITLE
feat: predictions

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,8 @@ import cloudinaryConfig from './config/cloudinary.config';
 import { PrismaModule } from './prisma/prisma.module';
 import { UploadsModule } from './uploads/uploads.module';
 import { AuthModule } from './auth/auth.module';
+import { PredictionsModule } from './predictions/predictions.module';
+import { MlModule } from './ml/ml.module';
 
 @Module({
   imports: [
@@ -18,6 +20,8 @@ import { AuthModule } from './auth/auth.module';
     PrismaModule,
     UploadsModule,
     AuthModule,
+    PredictionsModule,
+    MlModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   HttpCode,
+  Patch,
   Post,
   Req,
   Res,
@@ -116,7 +117,7 @@ export class AuthController {
     return req.user;
   }
 
-  @Post('me')
+  @Patch('me')
   @Auth()
   @UsePipes(new ZodValidationPipe(UpdateProfileSchema))
   async updateMe(@Req() req, @Body() dto: any) {

--- a/src/ml/ml.module.ts
+++ b/src/ml/ml.module.ts
@@ -1,0 +1,5 @@
+import { Module } from '@nestjs/common';
+import { MlService } from './ml.service';
+
+@Module({ providers: [MlService], exports: [MlService] })
+export class MlModule {}

--- a/src/ml/ml.service.ts
+++ b/src/ml/ml.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import axios from 'axios';
+
+@Injectable()
+export class MlService {
+  private base = process.env.ML_BASE_URL!;
+
+  async health() {
+    const { data } = await axios.get(`${this.base}/api/health`);
+    return data;
+  }
+
+  async predict(input: any) {
+    const { data } = await axios.post(`${this.base}/api/predict`, input, {
+      headers: { 'Content-Type': 'application/json' },
+    });
+    return data;
+  }
+}

--- a/src/predictions/dtos/list-query-prediction.dto.ts
+++ b/src/predictions/dtos/list-query-prediction.dto.ts
@@ -1,0 +1,13 @@
+import { ListQuerySchema } from 'src/common/dto/list-query.dto';
+import z from 'zod';
+
+export const PredictionsListSchema = ListQuerySchema.extend({
+  predictedClass: z.enum(['YES', 'NO']).optional(),
+  customerId: z.string().optional(),
+  source: z.string().optional(),
+  probYesMin: z.coerce.number().min(0).max(1).optional(),
+  probYesMax: z.coerce.number().min(0).max(1).optional(),
+  probNoMin: z.coerce.number().min(0).max(1).optional(),
+  probNoMax: z.coerce.number().min(0).max(1).optional(),
+});
+export type PredictionsListDto = z.infer<typeof PredictionsListSchema>;

--- a/src/predictions/dtos/update-prediction.dto.ts
+++ b/src/predictions/dtos/update-prediction.dto.ts
@@ -1,0 +1,11 @@
+import z from 'zod';
+
+export const UpdatePredictionSchema = z.object({
+  predictedClass: z.enum(['YES', 'NO']).optional(),
+  probabilityYes: z.coerce.number().min(0).max(1).optional(),
+  probabilityNo: z.coerce.number().min(0).max(1).optional(),
+  source: z.string().min(1).optional(),
+  timestamp: z.coerce.date().optional(),
+});
+
+export type UpdatePredictionDto = z.infer<typeof UpdatePredictionSchema>;

--- a/src/predictions/predictions.controller.ts
+++ b/src/predictions/predictions.controller.ts
@@ -1,0 +1,51 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+  Param,
+  Patch,
+  Delete,
+  UsePipes,
+} from '@nestjs/common';
+import { PredictionsService } from './predictions.service';
+import { Auth } from '../common/decorators/auth.decorator';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import {
+  PredictionsListDto,
+  PredictionsListSchema,
+} from './dtos/list-query-prediction.dto';
+import { UpdatePredictionDto } from './dtos/update-prediction.dto';
+
+@Controller('predictions')
+@Auth()
+export class PredictionsController {
+  constructor(private svc: PredictionsService) {}
+
+  @Get()
+  @UsePipes(new ZodValidationPipe(PredictionsListSchema))
+  list(@Query() query: PredictionsListDto) {
+    return this.svc.list(query);
+  }
+
+  @Get(':id')
+  detail(@Param('id') id: string) {
+    return this.svc.detail(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdatePredictionDto) {
+    return this.svc.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.svc.remove(id);
+  }
+
+  @Post('single')
+  async predictSingle(@Body() dto: { customerId: string }) {
+    return this.svc.predictSingle(dto.customerId);
+  }
+}

--- a/src/predictions/predictions.module.ts
+++ b/src/predictions/predictions.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PredictionsController } from './predictions.controller';
+import { PredictionsService } from './predictions.service';
+import { MlModule } from '../ml/ml.module';
+
+@Module({
+  imports: [MlModule],
+  controllers: [PredictionsController],
+  providers: [PredictionsService],
+  exports: [PredictionsService],
+})
+export class PredictionsModule {}

--- a/src/predictions/predictions.service.ts
+++ b/src/predictions/predictions.service.ts
@@ -1,0 +1,229 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { MlService } from '../ml/ml.service';
+import {
+  ListParams,
+  buildDateRange,
+  resolveSort,
+  paginate,
+  meta,
+} from '../common/utils/list.util';
+import { UpdatePredictionDto } from './dtos/update-prediction.dto';
+
+@Injectable()
+export class PredictionsService {
+  constructor(
+    private prisma: PrismaService,
+    private ml: MlService,
+  ) {}
+
+  async list(query: ListParams) {
+    const { page, take, skip } = paginate(query.page, query.limit);
+
+    const allowedSort = [
+      'timestamp',
+      'predictedClass',
+      'probabilityYes',
+      'probabilityNo',
+    ];
+    const orderBy = resolveSort(
+      query.sortBy,
+      (query.sortDir as 'asc' | 'desc') ?? 'desc',
+      allowedSort,
+      { timestamp: 'desc' },
+    );
+
+    const ts = buildDateRange(query.from, query.to);
+
+    const where: any = {};
+    if (ts) where.timestamp = ts;
+    if (query.predictedClass) where.predictedClass = query.predictedClass;
+    if (query.customerId) where.customerId = query.customerId;
+    if (query.source) where.source = query.source;
+
+    if (query.probYesMin || query.probYesMax) {
+      where.probabilityYes = {};
+      if (query.probYesMin) where.probabilityYes.gte = Number(query.probYesMin);
+      if (query.probYesMax) where.probabilityYes.lte = Number(query.probYesMax);
+    }
+    if (query.probNoMin || query.probNoMax) {
+      where.probabilityNo = {};
+      if (query.probNoMin) where.probabilityNo.gte = Number(query.probNoMin);
+      if (query.probNoMax) where.probabilityNo.lte = Number(query.probNoMax);
+    }
+
+    if (query.q) {
+      where.OR = [
+        { customer: { name: { contains: query.q, mode: 'insensitive' } } },
+        { customer: { job: { contains: query.q, mode: 'insensitive' } } },
+      ];
+    }
+
+    const [items, total] = await Promise.all([
+      this.prisma.prediction.findMany({
+        where,
+        skip,
+        take,
+        orderBy,
+        include: {
+          customer: {
+            select: {
+              id: true,
+              name: true,
+              job: true,
+              marital: true,
+              age: true,
+            },
+          },
+        },
+      }),
+      this.prisma.prediction.count({ where }),
+    ]);
+
+    return { items, meta: meta(total, page, take) };
+  }
+
+  async detail(id: string) {
+    const p = await this.prisma.prediction.findUnique({
+      where: { id },
+      include: {
+        customer: {
+          select: { id: true, name: true, job: true, marital: true, age: true },
+        },
+      },
+    });
+    if (!p) throw new NotFoundException('Prediction not found');
+    return p;
+  }
+
+  async update(id: string, dto: UpdatePredictionDto) {
+    const existing = await this.prisma.prediction.findUnique({ where: { id } });
+    if (!existing) throw new NotFoundException('Prediction not found');
+
+    const { probabilityYes, probabilityNo } = this.normalizeProbs(
+      dto.probabilityYes,
+      dto.probabilityNo,
+      dto.predictedClass ?? (existing.predictedClass as 'YES' | 'NO'),
+    );
+
+    const newClass =
+      dto.predictedClass ??
+      (probabilityYes !== undefined && probabilityNo !== undefined
+        ? probabilityYes >= probabilityNo
+          ? 'YES'
+          : 'NO'
+        : undefined);
+
+    const payload: any = {
+      ...(dto.source ? { source: dto.source } : {}),
+      ...(dto.timestamp ? { timestamp: dto.timestamp } : {}),
+      ...(newClass ? { predictedClass: newClass } : {}),
+      ...(probabilityYes !== undefined ? { probabilityYes } : {}),
+      ...(probabilityNo !== undefined ? { probabilityNo } : {}),
+    };
+
+    if (!Object.keys(payload).length) {
+      throw new BadRequestException('No valid fields to update');
+    }
+
+    return this.prisma.prediction.update({
+      where: { id },
+      data: payload,
+    });
+  }
+
+  async remove(id: string) {
+    const existing = await this.prisma.prediction.findUnique({ where: { id } });
+    if (!existing) throw new NotFoundException('Prediction not found');
+    await this.prisma.prediction.delete({ where: { id } });
+    return { ok: true };
+  }
+
+  async predictSingle(customerId: string) {
+    const cust = await this.prisma.customer.findUnique({
+      where: { id: customerId },
+    });
+    if (!cust) throw new NotFoundException('Customer not found');
+
+    const payload = {
+      age: cust.age,
+      job: cust.job,
+      marital: cust.marital,
+      education: cust.education,
+      default: 'no',
+      housing: cust.housing,
+      loan: cust.loan,
+      contact: cust.contact,
+      month: cust.month,
+      day_of_week: cust.day_of_week,
+      duration: 0,
+      campaign: cust.campaign,
+      pdays: cust.pdays,
+      previous: cust.previous,
+      poutcome: cust.poutcome,
+      emp_var_rate: cust.emp_var_rate,
+      cons_price_idx: cust.cons_price_idx,
+      cons_conf_idx: cust.cons_conf_idx,
+      euribor3m: cust.euribor3m,
+      nr_employed: cust.nr_employed,
+    };
+
+    const res = await this.ml.predict(payload);
+    const saved = await this.prisma.prediction.create({
+      data: {
+        customerId,
+        predictedClass: res?.data?.predicted_class ?? 'NO',
+        probabilityYes: res?.data?.probability_yes ?? 0,
+        probabilityNo: res?.data?.probability_no ?? 1,
+        source: 'single',
+      },
+    });
+    return saved;
+  }
+
+  private normalizeProbs(
+    py?: number,
+    pn?: number,
+    _klass?: 'YES' | 'NO',
+  ): { probabilityYes?: number; probabilityNo?: number } {
+    const inRange = (v: number) => v >= 0 && v <= 1;
+
+    if (py === undefined && pn === undefined) return {};
+
+    if (py !== undefined && !inRange(py)) {
+      throw new BadRequestException('probabilityYes must be between 0 and 1');
+    }
+    if (pn !== undefined && !inRange(pn)) {
+      throw new BadRequestException('probabilityNo must be between 0 and 1');
+    }
+
+    if (py !== undefined && pn !== undefined) {
+      const sum = py + pn;
+      if (Math.abs(sum - 1) > 0.05) {
+        const y = py / sum;
+        const n = pn / sum;
+        return { probabilityYes: +y.toFixed(3), probabilityNo: +n.toFixed(3) };
+      }
+      return { probabilityYes: +py.toFixed(3), probabilityNo: +pn.toFixed(3) };
+    }
+
+    if (py !== undefined) {
+      return {
+        probabilityYes: +py.toFixed(3),
+        probabilityNo: +(1 - py).toFixed(3),
+      };
+    }
+    if (pn !== undefined) {
+      return {
+        probabilityNo: +pn.toFixed(3),
+        probabilityYes: +(1 - pn).toFixed(3),
+      };
+    }
+
+    return {};
+  }
+}


### PR DESCRIPTION
# PR: Prediction Scoring Module (NestJS)

> Scope: **only** `predictions/`, `ml/`

## Summary

Implementasi modul **Prediction Scoring** untuk integrasi service ML dan pengelolaan hasil prediksi (CRUD, filter, sort, pagination) pada customer.

## What’s included

* **ML**: `MlModule`, `MlService` untuk koneksi ke service ML (`/api/health`, `/api/predict`) via Axios.
* **Predictions**: controller + service lengkap (`list/detail/update/delete/single predict`) dengan validasi Zod dan proteksi `@Auth()`.
* **DTO + Validation**: `PredictionsListSchema`, `UpdatePredictionSchema` untuk filter, sort, pagination, dan validasi payload update.
* **Prisma Integration**: relasi `Prediction` ↔ `Customer`, filtering & eager load customer di query list/detail.
* **Utilities**: normalisasi probabilitas otomatis, list util (`paginate/sort/dateRange/search`), dan exception handling.

## Endpoints (Predictions)

* `GET    /predictions`
* `GET    /predictions/:id`
* `POST   /predictions/single`
* `PATCH  /predictions/:id`
* `DELETE /predictions/:id`

## Proof / Evidence

<img width="1162" height="563" alt="image" src="https://github.com/user-attachments/assets/44f8fea3-8e95-4444-97c0-3cf140a3311e" />

## Checklist

* [x] Endpoint `POST /predictions/single` terhubung ke ML & menyimpan hasil ke DB
* [x] Filter/sort/pagination berfungsi (`ListQuerySchema` + `PredictionsListSchema`)
* [x] Endpoint `PATCH /predictions/:id` mendukung normalisasi probabilitas
* [x] Semua endpoint dilindungi `@Auth()`
* [x] Validasi aktif via `ZodValidationPipe`
* [x] Response & error shaping konsisten (global interceptor/filter aktif)
